### PR TITLE
Improve error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: precise
 jdk:
 - oraclejdk8
 - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk:
 - oraclejdk8
 - oraclejdk7
 script:
-- gradle -i check
+- ./gradlew -i check
 after_success:
 - ./gradlew cobertura coveralls
 notifications:

--- a/src/main/java/com/invoiced/entity/Connection.java
+++ b/src/main/java/com/invoiced/entity/Connection.java
@@ -5,6 +5,9 @@ import java.util.HashMap;
 import com.invoiced.exception.ApiException;
 import com.invoiced.exception.AuthException;
 import com.invoiced.exception.ConnException;
+import com.invoiced.exception.InvalidRequestException;
+import com.invoiced.exception.InvoicedException;
+import com.invoiced.exception.RateLimitException;
 import com.invoiced.util.ListResponse;
 import com.invoiced.util.Util;
 import com.mashape.unirest.http.HttpResponse;
@@ -23,8 +26,7 @@ public class Connection {
 	private boolean testMode;
 	private boolean autoRefresh;
 
-	protected String post(String url, HashMap<String, Object> queryParms, String jsonBody)
-	throws ApiException, AuthException, ConnException {
+	protected String post(String url, HashMap<String, Object> queryParms, String jsonBody) throws InvoicedException {
 
 		String responseString = "";
 		int responseCode = -1;
@@ -35,8 +37,8 @@ public class Connection {
 
 		try {
 			HttpResponse<String> response = Unirest.post(url).basicAuth(this.apiKey, "")
-			                                .header("accept", Connection.Accept).header("Content-Type", "application/json")
-			                                .queryString(queryParms).body(jsonBody).asString();
+					.header("accept", Connection.Accept).header("Content-Type", "application/json")
+					.queryString(queryParms).body(jsonBody).asString();
 			responseString = response.getBody().toString();
 			responseCode = response.getStatus();
 
@@ -44,10 +46,8 @@ public class Connection {
 			throw new ConnException(c);
 		}
 
-		if (responseCode == 401) {
-			throw new AuthException(responseString);
-		} else if (responseCode == 400 || responseCode == 403 || responseCode == 404) {
-			throw new ApiException(responseString);
+		if (responseCode >= 400) {
+			throw this.handleApiError(responseCode, responseString);
 		}
 
 		return responseString;
@@ -61,7 +61,7 @@ public class Connection {
 		}
 	}
 
-	protected String patch(String url, String jsonBody) throws ApiException, AuthException, ConnException {
+	protected String patch(String url, String jsonBody) throws InvoicedException {
 
 		String responseString = "";
 		int responseCode = -1;
@@ -72,8 +72,8 @@ public class Connection {
 
 		try {
 			HttpResponse<String> response = Unirest.patch(url).basicAuth(this.apiKey, "")
-			                                .header("accept", Connection.Accept).header("Content-Type", "application/json").body(jsonBody)
-			                                .asString();
+					.header("accept", Connection.Accept).header("Content-Type", "application/json").body(jsonBody)
+					.asString();
 			responseString = response.getBody().toString();
 			responseCode = response.getStatus();
 
@@ -81,17 +81,14 @@ public class Connection {
 			throw new ConnException(c);
 		}
 
-		if (responseCode == 401) {
-			throw new AuthException(responseString);
-		} else if (responseCode == 400 || responseCode == 403 || responseCode == 404) {
-			throw new ApiException(responseString);
+		if (responseCode >= 400) {
+			throw this.handleApiError(responseCode, responseString);
 		}
 
 		return responseString;
 	}
 
-	protected String get(String url, HashMap<String, Object> queryParms)
-	throws ApiException, AuthException, ConnException {
+	protected String get(String url, HashMap<String, Object> queryParms) throws InvoicedException {
 
 		String responseString = "";
 		int responseCode = -1;
@@ -102,8 +99,8 @@ public class Connection {
 
 		try {
 			HttpResponse<String> response = Unirest.get(url).basicAuth(this.apiKey, "")
-			                                .header("accept", Connection.Accept).header("Content-Type", "application/json")
-			                                .queryString(queryParms).asString();
+					.header("accept", Connection.Accept).header("Content-Type", "application/json")
+					.queryString(queryParms).asString();
 
 			responseString = response.getBody().toString();
 			responseCode = response.getStatus();
@@ -112,19 +109,14 @@ public class Connection {
 			throw new ConnException(c);
 		}
 
-		if (responseCode == 401) {
-			throw new AuthException(responseString);
-		} else if (responseCode == 400 || responseCode == 403 || responseCode == 404) {
-			throw new ApiException(responseString);
-		} else if (responseCode != 200 && responseCode != 204 && responseCode != 204) {
-			throw new ApiException(responseString);
+		if (responseCode >= 400) {
+			throw this.handleApiError(responseCode, responseString);
 		}
 
 		return responseString;
 	}
 
-	protected ListResponse getList(String url, HashMap<String, Object> queryParms)
-	throws ApiException, AuthException, ConnException {
+	protected ListResponse getList(String url, HashMap<String, Object> queryParms) throws InvoicedException {
 
 		String responseString = "";
 		int responseCode = -1;
@@ -137,8 +129,8 @@ public class Connection {
 
 		try {
 			HttpResponse<String> response = Unirest.get(url).basicAuth(this.apiKey, "")
-			                                .header("accept", Connection.Accept).header("Content-Type", "application/json")
-			                                .queryString(queryParms).asString();
+					.header("accept", Connection.Accept).header("Content-Type", "application/json")
+					.queryString(queryParms).asString();
 
 			responseString = response.getBody().toString();
 			responseCode = response.getStatus();
@@ -155,16 +147,14 @@ public class Connection {
 			throw new ConnException(c);
 		}
 
-		if (responseCode == 401) {
-			throw new AuthException(responseString);
-		} else if (responseCode == 400 || responseCode == 403 || responseCode == 404) {
-			throw new ApiException(responseString);
+		if (responseCode >= 400) {
+			throw this.handleApiError(responseCode, responseString);
 		}
 
 		return apiResult;
 	}
 
-	protected void delete(String url) throws ApiException, AuthException, ConnException {
+	protected void delete(String url) throws InvoicedException {
 
 		int responseCode = -1;
 		String responseString = "";
@@ -175,7 +165,7 @@ public class Connection {
 
 		try {
 			HttpResponse<String> response = Unirest.delete(url).basicAuth(this.apiKey, "")
-			                                .header("accept", Connection.Accept).header("Content-Type", "application/json").asString();
+					.header("accept", Connection.Accept).header("Content-Type", "application/json").asString();
 
 			responseCode = response.getStatus();
 
@@ -187,14 +177,8 @@ public class Connection {
 			throw new ConnException(c);
 		}
 
-		if (responseCode == 401) {
-			throw new AuthException(responseString);
-		} else if (responseCode == 400 || responseCode == 403 || responseCode == 404) {
-			throw new ApiException(responseString);
-		}
-
-		if (responseCode != 204) {
-			throw new ApiException("Object not deleted");
+		if (responseCode >= 400) {
+			throw this.handleApiError(responseCode, responseString);
 		}
 	}
 
@@ -258,4 +242,15 @@ public class Connection {
 		return baseEndPointProduction;
 	}
 
+	protected final InvoicedException handleApiError(int responseCode, String responseBody) {
+		if (responseCode == 401) {
+			return new AuthException(responseBody);
+		} else if (responseCode == 400) {
+			return new InvalidRequestException(responseBody);
+		} else if (responseCode == 429) {
+			return new RateLimitException(responseBody);
+		}
+
+		return new ApiException(responseBody);
+	}
 }

--- a/src/main/java/com/invoiced/exception/ApiException.java
+++ b/src/main/java/com/invoiced/exception/ApiException.java
@@ -1,6 +1,6 @@
 package com.invoiced.exception;
 
-public class ApiException extends Exception {
+public class ApiException extends InvoicedException {
 
 	private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/invoiced/exception/AuthException.java
+++ b/src/main/java/com/invoiced/exception/AuthException.java
@@ -1,6 +1,6 @@
 package com.invoiced.exception;
 
-public class AuthException extends Exception {
+public class AuthException extends InvoicedException {
 
 	private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/invoiced/exception/ConnException.java
+++ b/src/main/java/com/invoiced/exception/ConnException.java
@@ -1,11 +1,10 @@
 package com.invoiced.exception;
 
-public class ConnException extends Exception {
+public class ConnException extends InvoicedException {
 
 	private static final long serialVersionUID = 1L;
 
 	public ConnException(Throwable cause) {
 		super(cause);
 	}
-
 }

--- a/src/main/java/com/invoiced/exception/EntityException.java
+++ b/src/main/java/com/invoiced/exception/EntityException.java
@@ -1,6 +1,6 @@
 package com.invoiced.exception;
 
-public class EntityException extends Exception {
+public class EntityException extends InvoicedException {
 
 	private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/invoiced/exception/InvalidRequestException.java
+++ b/src/main/java/com/invoiced/exception/InvalidRequestException.java
@@ -1,0 +1,9 @@
+package com.invoiced.exception;
+
+public class InvalidRequestException extends InvoicedException {
+	private static final long serialVersionUID = 1L;
+
+	public InvalidRequestException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/invoiced/exception/InvoicedException.java
+++ b/src/main/java/com/invoiced/exception/InvoicedException.java
@@ -1,0 +1,13 @@
+package com.invoiced.exception;
+
+abstract public class InvoicedException extends Exception {
+	private static final long serialVersionUID = 1L;
+
+	public InvoicedException(Throwable cause) {
+		super(cause);
+	}
+
+	public InvoicedException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/invoiced/exception/RateLimitException.java
+++ b/src/main/java/com/invoiced/exception/RateLimitException.java
@@ -1,0 +1,9 @@
+package com.invoiced.exception;
+
+public class RateLimitException extends InvoicedException {
+	private static final long serialVersionUID = 1L;
+
+	public RateLimitException(String message) {
+		super(message);
+	}
+}

--- a/src/test/resources/mappings/connection_rr_55.json
+++ b/src/test/resources/mappings/connection_rr_55.json
@@ -1,0 +1,19 @@
+ {
+    "request": {
+        "method": "POST",
+        "url": "/customers",
+        "bodyPatterns": [
+      {
+        "equalToJson": "{ \"email\":\"billing@acmecorp.com\",\n  \"collection_mode\":\"manual\",\n  \"payment_terms\":\"NET 30\",\n  \"type\":\"company\",\n  \"rate_limit\":true \n }"
+      }
+    ]
+
+    },
+    "response": {
+        "status": 429,
+        "body": "{\n    \"type\": \"rate_limit_error\",\n    \"message\": \"You have reached your rate limit\"}",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/src/test/resources/mappings/connection_rr_56.json
+++ b/src/test/resources/mappings/connection_rr_56.json
@@ -1,0 +1,19 @@
+ {
+    "request": {
+        "method": "POST",
+        "url": "/customers",
+        "bodyPatterns": [
+      {
+        "equalToJson": "{ \"email\":\"billing@acmecorp.com\",\n  \"collection_mode\":\"manual\",\n  \"payment_terms\":\"NET 30\",\n  \"type\":\"company\",\n  \"auth_error\":true \n }"
+      }
+    ]
+
+    },
+    "response": {
+        "status": 401,
+        "body": "{\n    \"type\": \"authentication_error\",\n    \"message\": \"Invalid API key: XXXX\",\n    \"param\": \"name\"\n}",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/src/test/resources/mappings/connection_rr_57.json
+++ b/src/test/resources/mappings/connection_rr_57.json
@@ -1,0 +1,19 @@
+ {
+    "request": {
+        "method": "POST",
+        "url": "/customers",
+        "bodyPatterns": [
+      {
+        "equalToJson": "{ \"email\":\"billing@acmecorp.com\",\n  \"collection_mode\":\"manual\",\n  \"payment_terms\":\"NET 30\",\n  \"type\":\"company\",\n  \"server_error\":true \n }"
+      }
+    ]
+
+    },
+    "response": {
+        "status": 500,
+        "body": "{\n    \"type\": \"server_error\",\n    \"message\": \"Internal Server Error\"\n}",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/src/test/resources/mappings/connection_rr_8.json
+++ b/src/test/resources/mappings/connection_rr_8.json
@@ -4,7 +4,7 @@
         "url": "/customers",
         "bodyPatterns": [
       {
-        "equalToJson": "{ \"email\":\"billing@acmecorp.com\",\n  \"collection_mode\":\"manual\",\n  \"payment_terms\":\"NET 30\",\n  \"type\":\"company\" \n }"
+        "equalToJson": "{ \"email\":\"billing@acmecorp.com\",\n  \"collection_mode\":\"manual\",\n  \"payment_terms\":\"NET 30\",\n  \"type\":\"company\",\n  \"invalid_request\":true \n }"
       }
     ]
 


### PR DESCRIPTION
This PR adds several improvements to the error handling:
- Always throw an exception for 4xx and 5xx error codes
- All exceptions generated by this library inherit `com.invoiced.exception.InvoicedException`
- Added exceptions for invalid request and rate limiting errors

Related issues: #7 #5 