### PR TITLE
Updated Travis & gradle settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 #build folder
 build
 
+#vscode folder
+.vscode/
+
 #gradle folder
 .gradle/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: precise
 jdk:
 - oraclejdk8
 - oraclejdk9
-- oraclejdk10
 - oraclejdk11
 - oraclejdk12
 - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
-dist: precise
 jdk:
 - openjdk9
 - openjdk10

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
 script:
 - ./gradlew -i check
 after_success:
-- ./gradlew cobertura coveralls
+- ./gradlew test jacocoTestReport coveralls
 notifications:
   email: false
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 dist: precise
 jdk:
+- openjdk8
+- openjdk9
 - openjdk10
 - openjdk11
 - openjdk12

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,12 @@ language: java
 dist: precise
 jdk:
 - oraclejdk8
+- oraclejdk9
+- oraclejdk10
 - oraclejdk11
 - oraclejdk12
+- openjdk11
+- openjdk12
 script:
 - ./gradlew -i check
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
+- openjdk8
 - openjdk9
 - openjdk10
 - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: java
 dist: precise
 jdk:
 - oraclejdk8
-- oraclejdk7
+- oraclejdk11
+- oraclejdk12
 script:
 - ./gradlew -i check
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 dist: precise
 jdk:
-- openjdk8
 - openjdk9
 - openjdk10
 - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: java
 dist: precise
 jdk:
-- oraclejdk8
-- oraclejdk9
-- oraclejdk11
-- oraclejdk12
+- openjdk10
 - openjdk11
 - openjdk12
 script:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "automatic"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ gradle fatJar
 ## Requirements
 
 - Gradle 5.6.4
-- Java 8+
+- Java 9+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ gradle fatJar
 ## Requirements
 
 - Gradle 5.6.4
-- Java 9+
+- Java 8+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ gradle fatJar
 
 ## Requirements
 
-- Gradle 3.0
-- Java 7+
+- Gradle 5.6.4
+- Java 8+
 
 ## Usage
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,3 +49,13 @@ dependencies {
     // 'test.useTestNG()' to your build script.
     testCompile 'junit:junit:4.12'
 }
+
+jacocoTestReport {
+    group = "Reporting"
+    reports {
+        xml.enabled true
+        html.enabled true
+        csv.enabled false
+        html.destination file("${buildDir}/reports/coverage/report.html")
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,9 @@
 
 plugins {
-    id 'net.saliman.cobertura' version '2.3.1'
     id 'com.github.kt3k.coveralls' version '2.6.3'
+    id 'jacoco'
 }
 
-cobertura.coverageFormats = ['html', 'xml']
 // Apply the java plugin to add support for Java
 apply plugin: 'java'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 16 11:46:53 CDT 2016
+#Fri Nov 15 11:07:53 CDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip


### PR DESCRIPTION
This PR updates `.travis.yml` and the gradle configuration such that builds can now succeed. This was accomplished by switching to jacoco for code coverage and moving from gradle v3 to v5.6.4. The JDKs tested moved from 7,8 to openjdk 8,9,10,11,12.