### PR TITLE
INVD-3149 fix URL duplicated concatenation

### DIFF
--- a/src/main/java/com/invoiced/entity/AbstractEntity.java
+++ b/src/main/java/com/invoiced/entity/AbstractEntity.java
@@ -307,11 +307,7 @@ public abstract class AbstractEntity<T extends AbstractEntity> {
       throw new EntityException(new Throwable("List operation not available on object."));
     }
 
-    String url = this.getEndpoint(false);
-
-    if (nextURL != null && nextURL.length() > 0) {
-      url = nextURL;
-    }
+    String url = nextURL != null && nextURL.length() > 0 ? nextURL : this.conn.baseUrl() + this.getEndpoint(false);
 
     EntityList<T> entities = null;
 

--- a/src/main/java/com/invoiced/entity/Connection.java
+++ b/src/main/java/com/invoiced/entity/Connection.java
@@ -153,8 +153,6 @@ public final class Connection {
       this.refreshUnirestConnection();
     }
 
-    url = this.baseUrl() + url;
-
     ListResponse apiResult;
 
     try {


### PR DESCRIPTION
nextURL already contain base URL - so, to prevent concatenation it with itself - it was moved to the upper level, and concatenation is applied only if nextURL is not set 

##Before
![image](https://user-images.githubusercontent.com/54038605/198366145-f22f7330-d99c-46a3-9a3a-237a6caa5d40.png)


##After
![image](https://user-images.githubusercontent.com/54038605/198365811-125b884c-408f-46da-a4eb-bbc691e4c004.png)
